### PR TITLE
fix: add responsiveness on whole website 

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -165,3 +165,16 @@
       margin-block: 1.5rem;
     }
   }
+
+
+@media screen and (max-width: 650px) {
+  .content {
+    flex-direction: column;
+    width: 100%;
+  }
+  .divider {
+    height: 1px;
+    width: 100%;
+    margin-block: 1.5rem;
+  }
+}

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -178,3 +178,13 @@
     margin-block: 1.5rem;
   }
 }
+/* src/app/app.css */
+main {
+  padding-top: 4rem; /* or whatever your navbar height is */
+}
+@media (max-width: 640px) {
+  main {
+    padding-top: 19.5rem; /* smaller padding for mobile if navbar is shorter */
+  }
+}
+ 

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -2,7 +2,7 @@
   <app-nav></app-nav>
 
   <main class="flex-1 bg-stone-100 flex justify-center items-center">
-    <div class="w-1/2 px-4 py-6">
+    <div class="w-full max-w-2xl sm:w-3/4 md:w-2/3 lg:w-1/2 px-2 sm:px-4 py-4 sm:py-6">
       <router-outlet></router-outlet>
     </div>
   </main>

--- a/src/app/components/layout/nav/nav.html
+++ b/src/app/components/layout/nav/nav.html
@@ -1,4 +1,4 @@
-<nav class="bg-white border-b border-slate-200 shadow-sm fixed top-0 left-0 w-full z-50">
+<nav class="bg-white  border-b border-slate-200 shadow-sm fixed top-0 left-0 w-full z-50">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 py-4 flex flex-col sm:flex-row items-center justify-between">
         <div class="flex items-center gap-3 mb-2 pr-3 sm:mb-0">
           <i class="fas fa-magic text-indigo-600 text-3xl"></i>

--- a/src/app/components/layout/nav/nav.html
+++ b/src/app/components/layout/nav/nav.html
@@ -1,12 +1,13 @@
 <nav class="bg-white border-b border-slate-200 shadow-sm fixed top-0 left-0 w-full z-50">
-  <div class="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
-    <div class="flex items-center gap-3">
-      <i class="fas fa-magic text-indigo-600 text-3xl"></i>
-      <span class="text-3xl font-bold text-slate-800 font-sans"><a class="hover:text-indigo-600"
-            routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}">Text Tool</a></span>
-    </div>
-    
-    <ul class="flex gap-8 text-slate-700 text-base font-semibold">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 py-4 flex flex-col sm:flex-row items-center justify-between">
+        <div class="flex items-center gap-3 mb-2 pr-3 sm:mb-0">
+          <i class="fas fa-magic text-indigo-600 text-3xl"></i>
+          <span class="text-2xl sm:text-3xl font-bold text-slate-800 font-sans">
+            <a class="hover:text-indigo-600" routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}">Text Tool</a>
+          </span>
+        </div>
+        
+        <ul class="flex flex-col sm:flex-row gap-4 sm:gap-8 text-slate-700 text-base font-semibold w-full sm:w-auto">
       <li><a class="relative hover:text-indigo-600 after:content-[''] after:absolute after:left-0 after:-bottom-1 after:w-0 hover:after:w-full after:h-[2px] after:bg-indigo-600 after:transition-all after:duration-300"
             routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}">Home</a></li>
 

--- a/src/app/components/pages/home/home.html
+++ b/src/app/components/pages/home/home.html
@@ -1,5 +1,5 @@
-<div class="max-w-7xl mx-auto px-4 py-12">
-  <h1 class="text-3xl font-bold text-slate-800 mb-8">Available Tools</h1>
+<div class="max-w-7xl mx-auto px-4 py-12 pt-20">
+  <h1 class="text-3xl font-bold text-slate-800 mb-8  mt-64 sm:mt-4 ">Available Tools</h1>
 
   <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
     @for (tool of tools; track tool.title) {


### PR DESCRIPTION
## Improve Mobile Responsiveness for Home Page Section

### Summary
- Fixed the issue where the "Available Tools" heading was hidden behind the fixed navbar on small screens.
- Added responsive top margin so the section is always visible and well-spaced on all devices.

### Details
- Applied a top margin for screens below 550px to ensure proper spacing under the navbar.
- Ensured layout remains clean and consistent across all screen sizes.

 

Closes #3

